### PR TITLE
Bug: fix the link to selector.md in home page to resolve #33

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ zone.norm                # [(x0n,y0n), ...]             0.0 – 1.0
 zone.bbox                # → Box   tight bbox around the polygon
 zone.npoints             # int
 ```
-For more details, see [Selectors](docs/selectors.md).
+For more details, see [Selectors](selectors.md).
 
 ---
 


### PR DESCRIPTION
This PR resolves the issue #33 where the absolute path of docs/selector.md caused the link to not work in the documentation. 
