### PR TITLE
fix: accept LF (10) as Enter in select_line for cross-platform support

### DIFF
--- a/pixpick/backends/cv2_backend.py
+++ b/pixpick/backends/cv2_backend.py
@@ -64,7 +64,7 @@ class CV2Backend(BaseBackend):
                 self._boxes.clear()
                 continue
 
-            if key == 13:
+            if key in (13, 10):
                 if not self._boxes:
                     continue
 
@@ -112,7 +112,7 @@ class CV2Backend(BaseBackend):
                 self._points.clear()
                 continue
 
-            if key == 13:
+            if key in (13, 10):
                 if self._points:
                     if len(self._points) < 3:
                         continue
@@ -203,7 +203,7 @@ class CV2Backend(BaseBackend):
                 self._points.clear()
                 continue
 
-            if key == 13:
+            if key in (13, 10):
                 if not self._points:
                     continue
 

--- a/pixpick/backends/cv2_backend.py
+++ b/pixpick/backends/cv2_backend.py
@@ -167,7 +167,7 @@ class CV2Backend(BaseBackend):
                 continue
 
 
-            if key == 13:
+            if key in (13, 10):
                 if not self._lines or self._line_points:
                     continue
 


### PR DESCRIPTION
Follow-up to #73, as suggested.

`cv2.waitKey(20) & 0xFF` returns 10 (LF) rather than 13 (CR) on some
Linux/OpenCV builds, so Enter does not confirm the line selection there.
Accepting both keeps the behaviour consistent across platforms.

Scoped to `select_line` to match the change reviewed in #73 — happy to
extend it to the other selectors if you'd like consistency across all of them.